### PR TITLE
Bug on share URL in message

### DIFF
--- a/web-sample/static/js/util.js
+++ b/web-sample/static/js/util.js
@@ -141,12 +141,13 @@ function convertLinkMessage(msg) {
     msg = '';
   }
 
-  var urlexp = new RegExp('(http|ftp|https)://[a-z0-9\-_]+(\.[a-z0-9\-_]+)+([a-z0-9\-\.,@\?^=%&;:/~\+#]*[a-z0-9\-@\?^=%&;/~\+#])?', 'i');
-  if (urlexp.test(msg)) {
-    returnString += '<img src="/static/img/icon-link.svg" style="margin-right: 6px;"><a href="' + msg + '" target="_blank">' + msg + '</a>';
-  } else {
-    returnString += msg;
-  }
+  var linkIcon = '<img src="/static/img/icon-link.svg" style="margin-right: 6px;">';
 
-  return returnString;
+  var exp = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
+
+  returnString = msg.replace(exp, linkIcon + '<a target="_blank" href="$1">$1</a>');
+
+  var exp2 = /(^|[^\/])(www\.[\S]+(\b|$))/gim;
+
+  return returnString.replace(exp2, '$1'+ linkIcon +'<a target="_blank" href="http://$2">$2</a>');
 }

--- a/web-widget/src/js/elements/chat-section.js
+++ b/web-widget/src/js/elements/chat-section.js
@@ -1,6 +1,6 @@
 import { className, MAX_COUNT } from '../consts.js';
 import Element from './elements.js';
-import { show, hide, getFullHeight, removeClass, xssEscape } from '../utils.js';
+import { show, hide, getFullHeight, removeClass, xssEscape, convertLinkMessage } from '../utils.js';
 
 const EMPTY_STRING = '';
 
@@ -411,7 +411,9 @@ class ChatSection extends Element {
       var urlexp = new RegExp('(http|https)://[a-z0-9\-_]+(\.[a-z0-9\-_]+)+([a-z0-9\-\.,@\?^=%&;:/~\+#]*[a-z0-9\-@\?^=%&;/~\+#])?', 'i');
       var _message = message.message;
       if (urlexp.test(_message)) {
-        _message = '<a href="' + _message + (isCurrentUser ? '" target="_blank" style="color: #FFFFFF;">' : '" target="_blank" style="color: #444444;">') + _message + '</a>';
+        var linkColor = isCurrentUser ? '#FFFFFF' : '#444444';
+        _message = convertLinkMessage(_message, linkColor);
+
         if (message.customType === 'url_preview') {
           let previewData = JSON.parse(message.data);
 

--- a/web-widget/src/js/utils.js
+++ b/web-widget/src/js/utils.js
@@ -161,3 +161,22 @@ export function deleteCookie() {
     document.cookie = 'sendbirdNickname=' + userInfo.nickname + ';expires=Thu, 01 Jan 1970 00:00:01 GMT;';
   }
 }
+
+export function convertLinkMessage(msg, linkColor) {
+  var returnString = '';
+
+  try {
+    msg = msg.replace(/</g, '&lt;');
+    msg = msg.replace(/>/g, '&gt;');
+  } catch(e) {
+    msg = '';
+  }
+
+  var exp = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
+
+  returnString = msg.replace(exp, '<a target="_blank" style="color: '+linkColor+';" href="$1">$1</a>');
+
+  var exp2 = /(^|[^\/])(www\.[\S]+(\b|$))/gim;
+
+  return returnString.replace(exp2, '$1<a target="_blank" style="color: '+linkColor+';" href="http://$2">$2</a>');
+}


### PR DESCRIPTION
In both `web-sample` and `web-widget`, when sharing an URL with some text it converts entire message as a link.

For example:

On share message,
```
this is test http://example.com`. 
```
It converts this entire message as link as below:

**In web-sample**
```
<img src="/static/img/icon-link.svg" style="margin-right: 6px;"> <a target="_blank" href="this is test http://example.com">this is test http://example.com</a>
```

**In web-widget**
```
<a target="_blank" style="color:#FFFFFF;" href="this is test http://example.com">this is test http://example.com</a>
```

It puts the entire message in `href="this is test http://example.com"`.
Which is completely wrong and I have fixed it in this PR. 