### PR TITLE
Remove localStorage pushToken fetch

### DIFF
--- a/react-native-redux-sample/ReactNativeWithSendBird/src/screens/Login.js
+++ b/react-native-redux-sample/ReactNativeWithSendBird/src/screens/Login.js
@@ -29,21 +29,17 @@ class Login extends Component {
     componentWillReceiveProps(props) {
         let { user, error } = props;
         if (user) {
-            AsyncStorage.getItem('pushToken', (err, pushToken) => {
-                if(pushToken) {
-                    sbRegisterPushToken(pushToken)
-                        .then(res => {})
-                        .catch(err => {});
-                }
-                const resetAction = NavigationActions.reset({
-                    index: 0,
-                    actions: [
-                        NavigationActions.navigate({ routeName: 'Menu' })
-                    ]
-                });
-                this.setState({ userId: '', nickname: '', isLoading: false }, () => {
-                    this.props.navigation.dispatch(resetAction);
-                });
+            sbRegisterPushToken()
+                .then(res => {})
+                .catch(err => {});
+            const resetAction = NavigationActions.reset({
+                index: 0,
+                actions: [
+                    NavigationActions.navigate({ routeName: 'Menu' })
+                ]
+            });
+            this.setState({ userId: '', nickname: '', isLoading: false }, () => {
+                this.props.navigation.dispatch(resetAction);
             });
         }
 


### PR DESCRIPTION
We had some trouble enabling push notifications in your react native sample app and it seems that the problem was just some stale code. You never set the pushToken in localStorage at any point so the (now removed) conditional block was never getting executed and the app was not getting registered with FCM.

In our testing, after uninstalling/reinstalling the app the push notifications started up once after this fix.